### PR TITLE
 Provide hosts as environment settings and add npm run start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:6.9.5
+
+RUN apt-get update
+RUN apt-get install -y aspell aspell-en aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-alt aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-or aspell-pa aspell-pl aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-sv aspell-ta aspell-te aspell-tl aspell-uk aspell-uz

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -4,15 +4,15 @@ module.exports = Settings =
 	internal:
 		spelling:
 			port: 3005
-			host: "localhost"
+			host: process.env["LISTEN_ADDRESS"] or "localhost"
 			
 	redis:
-		port:6379
-		host:"127.0.0.1"
+		port: 6379
+		host: process.env["REDIS_HOST"] or "localhost"
 		password:""
 		
 	mongo:
-		url : 'mongodb://127.0.0.1/sharelatex'
+		url : "mongodb://#{process.env["MONGO_HOST"] or "localhost"}/sharelatex"
 
 	cacheDir: Path.resolve "cache"
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/spelling-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "version": "0.1.4",
   "dependencies": {
     "async": "0.1.22",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.

Also provides a Dockerfile which builds on the `node:6.9.5` base image, but adds aspell for server-side spell checking. This is used by the docker-compose file to run spelling.